### PR TITLE
Add start script and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# ChatGPT Chatbot
+
+## Setup
+
+1. **Install dependencies**
+   ```bash
+   npm install
+   ```
+
+2. **Configure the environment**
+   Create a `.env` file in the project root containing your OpenAI API key:
+   ```env
+   OPENAI_API_KEY=your_openai_api_key
+   ```
+
+3. **Start the server**
+   ```bash
+   npm start
+   ```
+
+The application will be available at `http://localhost:3000`.

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "start": "node server.js"
+  },
   "dependencies": {
     "dotenv": "^16.5.0",
     "express": "^5.1.0",


### PR DESCRIPTION
## Summary
- add start command in `package.json`
- document installation and startup steps in `README.md`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e1825a20c832a9c4a376f91d729e6