### PR TITLE
Add chat history and reset support

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,6 +16,7 @@
     <div class="chat-input">
         <input type="text" id="userInput" placeholder="Type your message...">
         <button id="sendButton">Send</button>
+        <button id="clearButton">Clear</button>
     </div>
 </div>
 
@@ -23,6 +24,7 @@
     document.addEventListener('DOMContentLoaded', () => {
         const userInput = document.getElementById('userInput');
         const sendButton = document.getElementById('sendButton');
+        const clearButton = document.getElementById('clearButton');
         const chatMessages = document.getElementById('chatMessages');
 
         const addMessage = (message, sender) => {
@@ -70,6 +72,10 @@
         };
 
         sendButton.addEventListener('click', handleSend);
+        clearButton.addEventListener('click', async () => {
+            await fetch('/reset', { method: 'POST' });
+            chatMessages.innerHTML = '';
+        });
         userInput.addEventListener('keydown', (event) => {
             if (event.key === 'Enter') {
                 handleSend();

--- a/public/styles.css
+++ b/public/styles.css
@@ -82,6 +82,21 @@ body {
     transition: background-color 0.3s;
 }
 
+#clearButton {
+    background-color: #e5e5ea;
+    color: #000000;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 20px;
+    cursor: pointer;
+    font-size: 16px;
+    margin-left: 10px;
+}
+
 #sendButton:hover {
     background-color: #0056b3;
+}
+
+#clearButton:hover {
+    background-color: #d5d5d9;
 }

--- a/server.js
+++ b/server.js
@@ -21,6 +21,13 @@ app.get('/', (req, res) => {
     res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
 
+// In-memory chat history
+const chatHistory = [];
+const systemPrompt = {
+    role: 'system',
+    content: 'You are ChatGPT, a helpful assistant.',
+};
+
 // API endpoint to handle chat requests
 app.post('/chat', async (req, res) => {
     try {
@@ -29,18 +36,31 @@ app.post('/chat', async (req, res) => {
             return res.status(400).json({ error: 'Message is required' });
         }
 
+        // Add user message to history
+        chatHistory.push({ role: 'user', content: message });
+
         const completion = await openai.chat.completions.create({
-            messages: [{ role: 'user', content: message }],
+            messages: [systemPrompt, ...chatHistory],
             model: 'gpt-3.5-turbo', // Or any other model like gpt-4
         });
 
         const botMessage = completion.choices[0].message.content;
+
+        // Save assistant response to history
+        chatHistory.push({ role: 'assistant', content: botMessage });
+
         res.json({ reply: botMessage });
 
     } catch (error) {
         console.error('Error calling OpenAI API:', error);
         res.status(500).json({ error: 'Failed to communicate with OpenAI' });
     }
+});
+
+// Endpoint to clear the chat history
+app.post('/reset', (req, res) => {
+    chatHistory.length = 0;
+    res.json({ message: 'Chat history cleared' });
 });
 
 app.listen(port, () => {


### PR DESCRIPTION
## Summary
- keep chat history on server
- send previous messages to OpenAI for context
- add endpoint and UI button to reset the conversation
- style the reset button

## Testing
- `npm install`
- `node server.js` *(fails: OpenAI API key missing)*

------
https://chatgpt.com/codex/tasks/task_e_684e1827fdd0832aa22a14c2b0078253