### PR TITLE
Switch to OpenAI Responses API

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,18 @@
    npm start
    ```
 
+The bot replies are generated via the OpenAI **Responses API** using
+`openai.responses.create`.
+
 Initial login
 -------------
 
 The repository includes a default admin user `admin@example.com`. Use the `/login.html`
 page to request a magic link for this email address. The login link will be printed
 to the console if SMTP is not configured.
+
+This application uses the OpenAI **Responses API** to generate replies instead of
+the older Chat Completions API.
 
 Admins can create additional users via the `/admin` page.
 

--- a/server.js
+++ b/server.js
@@ -156,12 +156,18 @@ app.post('/chat', requireAuth, async (req, res) => {
         // Add user message to history
         chatHistory.push({ role: 'user', content: message });
 
-        const completion = await openai.chat.completions.create({
-            messages: [systemPrompt, ...chatHistory],
-            model: 'gpt-3.5-turbo', // Or any other model like gpt-4
-        });
+        const params = {
+            input: message,
+            model: 'gpt-4o',
+            instructions: systemPrompt.content,
+        };
+        if (req.session.previousResponseId) {
+            params.previous_response_id = req.session.previousResponseId;
+        }
+        const completion = await openai.responses.create(params);
 
-        const botMessage = completion.choices[0].message.content;
+        const botMessage = completion.output_text;
+        req.session.previousResponseId = completion.id;
 
         // Save assistant response to history
         chatHistory.push({ role: 'assistant', content: botMessage });
@@ -177,6 +183,7 @@ app.post('/chat', requireAuth, async (req, res) => {
 // Endpoint to clear the chat history
 app.post('/reset', requireAuth, (req, res) => {
     chatHistory.length = 0;
+    req.session.previousResponseId = null;
     res.json({ message: 'Chat history cleared' });
 });
 


### PR DESCRIPTION
## Summary
- replace `chat.completions` with `openai.responses.create`
- store and clear `previousResponseId` in the session
- mention the new Responses API usage in README

## Testing
- `npm install`
- `node --check server.js`
- `OPENAI_API_KEY=dummy npm start` *(terminated after startup)*

------
https://chatgpt.com/codex/tasks/task_e_68518d0884e4832a96d8fe70b7758505